### PR TITLE
[fix] JSON output of name contains invalid field

### DIFF
--- a/src/main/java/org/osiam/resources/scim/Name.java
+++ b/src/main/java/org/osiam/resources/scim/Name.java
@@ -23,6 +23,7 @@
 
 package org.osiam.resources.scim;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Strings;
 
@@ -148,6 +149,7 @@ public class Name {
      *
      * @return true if all properties are null or empty, else false
      */
+    @JsonIgnore
     public boolean isEmpty() {
         if(!Strings.isNullOrEmpty(formatted)) {
             return false;

--- a/src/test/groovy/org/osiam/resources/scim/NameJsonSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/NameJsonSpec.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2014 tarent AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.osiam.resources.scim
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.json.JSONObject
+import spock.lang.Specification
+
+class NameJsonSpec extends Specification {
+
+    private final static ObjectMapper mapper = new ObjectMapper()
+
+    def 'isEmpty method should not be serialized to a field called empty'() {
+        given:
+        def name = new Name.Builder().build()
+
+        when:
+        def json = mapper.writeValueAsString(name)
+
+        then:
+        def jsonObject = new JSONObject(json)
+        !jsonObject.has('empty')
+    }
+
+}


### PR DESCRIPTION
the current json output of a Name instance contains the field 'empty'
that is invalid for this SCIM attribute. this is caused by the
'isEmpty()' method getting serialized by jackson. fixed it by annotating
the method with @JsonIgnore.
