### PR TITLE
Re-activate JSON tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Testing JSON -->
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.4.1</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Automated testing of the equals contract. LICENSE: Apache 2.0 according to source -->
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>

--- a/src/test/groovy/org/osiam/resources/scim/MemberRefSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/MemberRefSpec.groovy
@@ -23,25 +23,18 @@
 
 package org.osiam.resources.scim
 
-import spock.lang.Ignore
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.jayway.restassured.path.json.JsonPath
+import spock.lang.Shared
 import spock.lang.Specification
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import static com.jayway.restassured.path.json.JsonPath.from
 
 class MemberRefSpec extends Specification {
 
-    private ObjectMapper mapper = new ObjectMapper()
+    @Shared
+    ObjectMapper mapper = new ObjectMapper()
 
-    @Ignore('''We cannot use JSONAssert anymore, because of licensing issues. This
-            test has to be re-activated when:
-
-              1) JSONAssert fixes its licensing issues (see https://github.com/skyscreamer/JSONassert/issues/44)
-              2) An alternative library for comparing JSON has been found
-
-            Beware of the following: Whenever you change things in this project
-            that might affect the generated JSON you HAVE TO re-activate this
-            test, either using method 1), 2), or implementing an own JSON
-            test mechanism!''')
     def 'serializing member ref results in correct json'() {
         given:
         MemberRef memberRef = new MemberRef.Builder()
@@ -49,10 +42,10 @@ class MemberRefSpec extends Specification {
                 .build();
 
         when:
-        def json = mapper.writeValueAsString(memberRef)
+        JsonPath json = from(mapper.writeValueAsString(memberRef))
 
         then:
-        false
+        json.get('$ref') == 'irrelevant'
     }
 
     def 'deserializing member ref results in correct MemberRef object'() {

--- a/src/test/groovy/org/osiam/resources/scim/NameJsonSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/NameJsonSpec.groovy
@@ -24,32 +24,26 @@
 package org.osiam.resources.scim
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import spock.lang.Ignore
+import com.jayway.restassured.path.json.JsonPath
+import spock.lang.Shared
 import spock.lang.Specification
+
+import static com.jayway.restassured.path.json.JsonPath.from
 
 class NameJsonSpec extends Specification {
 
-    private final static ObjectMapper mapper = new ObjectMapper()
+    @Shared
+    ObjectMapper mapper = new ObjectMapper()
 
-    @Ignore('''We cannot use JSONAssert anymore, because of licensing issues. This
-            test has to be re-activated when:
-
-              1) JSONAssert fixes its licensing issues (see https://github.com/skyscreamer/JSONassert/issues/44)
-              2) An alternative library for comparing JSON has been found
-
-            Beware of the following: Whenever you change things in this project
-            that might affect the generated JSON you HAVE TO re-activate this
-            test, either using method 1), 2), or implementing an own JSON
-            test mechanism!''')
     def 'isEmpty method should not be serialized to a field called empty'() {
         given:
         def name = new Name.Builder().build()
 
         when:
-        def json = mapper.writeValueAsString(name)
+        JsonPath json = from(mapper.writeValueAsString(name))
 
         then:
-        false
+        json.getMap('$').containsKey('empty') == false
     }
 
 }

--- a/src/test/groovy/org/osiam/resources/scim/UserJsonSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/UserJsonSpec.groovy
@@ -23,50 +23,99 @@
 
 package org.osiam.resources.scim
 
-import org.osiam.test.util.JsonFixturesHelper
-import spock.lang.Ignore
-import spock.lang.Specification
-import spock.lang.Unroll
-
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.jayway.restassured.path.json.JsonPath
+import org.osiam.test.util.DateHelper
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.ByteBuffer
+
+import static com.jayway.restassured.path.json.JsonPath.from
 
 class UserJsonSpec extends Specification {
 
-    private static JsonFixturesHelper jsonFixtures = new JsonFixturesHelper()
+    @Shared
+    ObjectMapper mapper = new ObjectMapper()
 
-    private final static ObjectMapper mapper = new ObjectMapper()
+    def 'A User is correctly serialized'() {
+        given:
+        User user = new User.Builder('bjensen')
+                .setId('a4bbe688-4b1e-4e4e-80e7-e5ba5c4d6db4')
+                .setMeta(new Meta.Builder()
+                        .setLocation('https://example.com/v1/Users/2819c223...')
+                        .setResourceType('User').build())
+                .setSchemas(['urn:scim:schemas:core:2.0:User'] as Set)
+                .setExternalId('bjensen')
+                .setName(new Name.Builder()
+                        .setFormatted('Ms. Barbara J Jensen III')
+                        .setFamilyName('Jensen')
+                        .setGivenName('Barbara').build())
+                .setDisplayName('BarbaraJ.')
+                .setNickName('Barbara')
+                .setTitle('Dr.')
+                .setLocale('de')
+                .addEmail(new Email.Builder()
+                        .setValue('bjensen@example.com')
+                        .setType(Email.Type.WORK).build())
+                .addPhoto(new Photo.Builder()
+                        .setValue('example.png').build())
+                .addPhoneNumber(new PhoneNumber.Builder()
+                        .setValue('555-555-8377')
+                        .setType(PhoneNumber.Type.WORK).build())
+                .addAddress(new Address.Builder()
+                        .setType(Address.Type.WORK)
+                        .setStreetAddress('example street 42')
+                        .setLocality('Bonn')
+                        .setRegion('North Rhine-Westphalia')
+                        .setPostalCode('11111')
+                        .setCountry('Germany').build())
+                .addExtension(new Extension.Builder('urn:scim:schemas:extension:test:1.0:User')
+                        .setField('keyString', 'example')
+                        .setField('keyBoolean', true)
+                        .setField('keyInteger', 123G)
+                        .setField('keyDecimal', 123.456G)
+                        .setField('keyBinary', ByteBuffer.wrap([101, 120, 97, 109, 112, 108, 101] as byte[]))
+                        .setField('keyReference', new URI('https://example.com/Users/28'))
+                        .setField('keyDateTime', DateHelper.createDate(2008, 0, 23, 18, 29, 49)).build())
+                .build()
 
-    @Ignore('''We cannot use JSONAssert anymore, because of licensing issues. This
-            test has to be re-activated when:
-
-              1) JSONAssert fixes its licensing issues (see https://github.com/skyscreamer/JSONassert/issues/44)
-              2) An alternative library for comparing JSON has been found
-
-            Beware of the following: Whenever you change things in this project
-            that might affect the generated JSON you HAVE TO re-activate this
-            test, either using method 1), 2), or implementing an own JSON
-            test mechanism!''')
-    @Unroll
-    def 'A #userType User is correctly serialized' () {
         when:
-        def json = mapper.writeValueAsString(user)
+        JsonPath json = from(mapper.writeValueAsString(user))
+
         then:
-        false
-
-        where:
-        userType   | expectedJson                  | user
-        'simple'   | jsonFixtures.jsonSimpleUser   | mapSimpleUser()
-        'basic'    | jsonFixtures.jsonBasicUser    | mapBasicUser()
-        'extended' | jsonFixtures.jsonExtendedUser | mapExtendedUser()
+        json.getString('id') == 'a4bbe688-4b1e-4e4e-80e7-e5ba5c4d6db4'
+        json.getString('meta.location') == 'https://example.com/v1/Users/2819c223...'
+        json.getString('meta.resourceType') == 'User'
+        json.getList('schemas').containsAll(['urn:scim:schemas:core:2.0:User',
+                                             'urn:scim:schemas:extension:test:1.0:User'])
+        json.getString('externalId') == 'bjensen'
+        json.getString('userName') == 'bjensen'
+        json.getString('name.formatted') == 'Ms. Barbara J Jensen III'
+        json.getString('name.familyName') == 'Jensen'
+        json.getString('name.givenName') == 'Barbara'
+        json.getString('displayName') == 'BarbaraJ.'
+        json.getString('nickName') == 'Barbara'
+        json.getString('title') == 'Dr.'
+        json.getString('locale') == 'de'
+        json.getString('emails[0].value') == 'bjensen@example.com'
+        json.getString('emails[0].type') == 'work'
+        json.getString('photos[0].value') == 'example.png'
+        json.getString('phoneNumbers[0].value') == '555-555-8377'
+        json.getString('phoneNumbers[0].type') == 'work'
+        json.getString('addresses[0].type') == 'work'
+        json.getString('addresses[0].streetAddress') == 'example street 42'
+        json.getString('addresses[0].locality') == 'Bonn'
+        json.getString('addresses[0].region') == 'North Rhine-Westphalia'
+        json.getString('addresses[0].postalCode') == '11111'
+        json.getString('addresses[0].country') == 'Germany'
+        json.getString('\'urn:scim:schemas:extension:test:1.0:User\'.keyString') == 'example'
+        json.getBoolean('\'urn:scim:schemas:extension:test:1.0:User\'.keyBoolean') == true
+        json.getInt('\'urn:scim:schemas:extension:test:1.0:User\'.keyInteger') == 123
+        json.getDouble('\'urn:scim:schemas:extension:test:1.0:User\'.keyDecimal') == 123.456D
+        json.getString('\'urn:scim:schemas:extension:test:1.0:User\'.keyBinary') == 'ZXhhbXBsZQ=='
+        json.getString('\'urn:scim:schemas:extension:test:1.0:User\'.keyReference') == 'https://example.com/Users/28'
+        json.getString('\'urn:scim:schemas:extension:test:1.0:User\'.keyDateTime') == '2008-01-23T18:29:49.000Z'
     }
 
-    private User mapBasicUser(){
-        jsonFixtures.configuredObjectMapper().readValue(jsonFixtures.jsonBasicUser, User)
-    }
-    private User mapSimpleUser(){
-        jsonFixtures.configuredObjectMapper().readValue(jsonFixtures.jsonSimpleUser, User)
-    }
-    private User mapExtendedUser(){
-        jsonFixtures.configuredObjectMapper().readValue(jsonFixtures.jsonExtendedUser, User)
-    }
 }


### PR DESCRIPTION
This re-activates the JSON tests, i.e. the tests that specify how a
Resource will be serialized into JSON. This is done with the help of
Jayways's Rest Assured's JSON Path.