### PR TITLE
Deprecate User/Group/Resource#setSchemas(...)

### DIFF
--- a/src/main/java/org/osiam/resources/scim/Group.java
+++ b/src/main/java/org/osiam/resources/scim/Group.java
@@ -34,17 +34,16 @@ import com.google.common.base.Strings;
 
 /**
  * This class represent a Group resource.
- * 
+ *
  * <p>
- * For more detailed information please look at the <a
- * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-8">SCIM core schema 2.0, sections 8</a>
+ * For more detailed information please look at the
+ * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-8">SCIM core schema 2.0, sections 8</a>
  * </p>
- * 
+ *
  * <p>
- * client info: The scim schema is mainly meant as a connection link between the 
- * OSIAM server and by a client like the connector4Java. 
- * Some values will be not accepted by the OSIAM server.
- * These specific values have an own client info documentation section.
+ * client info: The scim schema is mainly meant as a connection link between the OSIAM server and by a client like the
+ * connector4Java. Some values will be not accepted by the OSIAM server. These specific values have an own client info
+ * documentation section.
  * </p>
  */
 @JsonInclude(Include.NON_EMPTY)
@@ -67,7 +66,7 @@ public class Group extends Resource {
 
     /**
      * Gets the human readable name of this {@link Group}.
-     * 
+     *
      * @return the display name
      */
     public String getDisplayName() {
@@ -76,12 +75,13 @@ public class Group extends Resource {
 
     /**
      * Gets the list of members of this Group.
-     * 
+     *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-8">SCIM core schema 2.0, sections 8</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-8">SCIM core schema 2.0, sections
+     * 8</a>
      * </p>
-     * 
+     *
      * @return the list of Members as a Set
      */
     public Set<MemberRef> getMembers() {
@@ -106,7 +106,7 @@ public class Group extends Resource {
         /**
          * creates a new Group.Builder based on the given displayName and group. All values of the given group will be
          * copied expect the displayName will be be overridden by the given one
-         * 
+         *
          * @param displayName
          *        the new displayName of the group
          * @param group
@@ -133,10 +133,10 @@ public class Group extends Resource {
 
         /**
          * Constructs a new builder by copying all values from the given {@link Group}
-         * 
+         *
          * @param group
          *        {@link Group} to be copied from
-         * 
+         *
          * @throws SCIMDataValidationException
          *         if the given group is null
          */
@@ -149,10 +149,10 @@ public class Group extends Resource {
 
         /**
          * Constructs a new builder and sets the display name (See {@link Group#getDisplayName()}).
-         * 
+         *
          * @param displayName
          *        the display name
-         * 
+         *
          * @throws SCIMDataValidationException
          *         if the displayName is null or empty
          */
@@ -181,7 +181,12 @@ public class Group extends Resource {
             return this;
         }
 
+        /**
+         * @deprecated Don't use this method - let the extensions add their schema themselves. Will be removed in
+         *             version 1.8 or 2.0
+         */
         @Override
+        @Deprecated
         public Builder setSchemas(Set<String> schemas) {
             super.setSchemas(schemas);
             return this;
@@ -189,7 +194,7 @@ public class Group extends Resource {
 
         /**
          * Sets the list of members as {@link Set} (See {@link Group#getMembers()}).
-         * 
+         *
          * @param members
          *        the set of members
          * @return the builder itself

--- a/src/main/java/org/osiam/resources/scim/Resource.java
+++ b/src/main/java/org/osiam/resources/scim/Resource.java
@@ -23,10 +23,10 @@
 
 package org.osiam.resources.scim;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.HashSet;
 import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * This class represents a SCIM Resource and is the base class for {@link User}s and {@link Group}s.
@@ -54,7 +54,7 @@ public abstract class Resource {
 
     /**
      * Gets the Id of the resource.
-     * 
+     *
      * @return the id of the resource
      */
     public String getId() {
@@ -63,15 +63,15 @@ public abstract class Resource {
 
     /**
      * Gets the external Id of the resource.
-     * 
+     *
      * <p>
-     * For more information please look at <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-5.1">SCIM core schema 2.0, section
+     * For more information please look at
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-5.1">SCIM core schema 2.0, section
      * 5.1</a>
      * </p>
-     * 
+     *
      * @return the externalId
-     * 
+     *
      */
     public String getExternalId() {
         return externalId;
@@ -79,7 +79,7 @@ public abstract class Resource {
 
     /**
      * Gets the meta attribute
-     * 
+     *
      * @return the meta
      */
     public Meta getMeta() {
@@ -88,7 +88,7 @@ public abstract class Resource {
 
     /**
      * Gets the list of defined schemas
-     * 
+     *
      * @return a the list of schemas as a {@link Set}
      */
     public Set<String> getSchemas() {
@@ -114,19 +114,17 @@ public abstract class Resource {
         }
 
         /**
-         * sets the schemas of the Resource
-         * 
-         * @param schemas
-         *            actual schemas
-         * @return the builder itself
+         * @deprecated Don't use this method - let the extensions add their schema themselves. Will be removed in
+         *             version 1.8 or 2.0
          */
+        @Deprecated
         public Builder setSchemas(Set<String> schemas) {
             this.schemas = schemas;
             return this;
         }
-        
-        protected void addSchema(String schema){
-            if(schemas == null){
+
+        protected void addSchema(String schema) {
+            if (schemas == null) {
                 schemas = new HashSet<>();
             }
             schemas.add(schema);
@@ -134,15 +132,15 @@ public abstract class Resource {
 
         /**
          * Sets the id of the resource.
-         * 
+         *
          * <p>
-         * client info: The id of a User will be created and set by the OSIAM server. 
-         * If a {@link User} or {@link Group} which is send to the OSIAM server has this value filled, 
-         * the value will be ignored or the action will be rejected.
+         * client info: The id of a User will be created and set by the OSIAM server. If a {@link User} or {@link Group}
+         * which is send to the OSIAM server has this value filled, the value will be ignored or the action will be
+         * rejected.
          * </p>
-         * 
+         *
          * @param id
-         *            if of the resource
+         *        if of the resource
          * @return the builder itself
          */
         public Builder setId(String id) {
@@ -152,10 +150,10 @@ public abstract class Resource {
 
         /**
          * Sets the external id (See {@link Resource#getExternalId()}).
-         * 
+         *
          * @param externalId
-         *            the external id
-         * 
+         *        the external id
+         *
          * @return the builder itself
          */
         public Builder setExternalId(String externalId) {
@@ -165,17 +163,16 @@ public abstract class Resource {
 
         /**
          * Sets the meta data
-         * 
+         *
          * <p>
-         * client info: The meta information of a User will be created and set by the OSIAM server. 
-         * If a {@link User} or {@link Group} which is send to the OSIAM server has this value filled, 
-         * the value will be ignored or the action will be rejected. 
-         * For an update(PATCH) the attribute value can be set by the client. In normal case this 
-         * should be set by the {@link UpdateUser} or {@link UpdateGroup} and not by the client directly. 
+         * client info: The meta information of a User will be created and set by the OSIAM server. If a {@link User} or
+         * {@link Group} which is send to the OSIAM server has this value filled, the value will be ignored or the
+         * action will be rejected. For an update(PATCH) the attribute value can be set by the client. In normal case
+         * this should be set by the {@link UpdateUser} or {@link UpdateGroup} and not by the client directly.
          * </p>
-         * 
+         *
          * @param meta
-         *            the meta object
+         *        the meta object
          * @return the builder itself
          */
         public Builder setMeta(Meta meta) {
@@ -185,7 +182,7 @@ public abstract class Resource {
 
         /**
          * Builds the Object of the Builder
-         * 
+         *
          * @return a new main Object of the Builder
          */
         public abstract <T> T build();

--- a/src/main/java/org/osiam/resources/scim/User.java
+++ b/src/main/java/org/osiam/resources/scim/User.java
@@ -38,8 +38,8 @@ import com.google.common.base.Strings;
  * used to store all customized data.
  *
  * <p>
- * For more detailed information please look at the <a
- * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+ * For more detailed information please look at the
+ * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
  * </p>
  *
  * <p>
@@ -111,8 +111,8 @@ public class User extends Resource {
      * Gets the unique identifier for the User.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
      * </p>
      *
      * @return the user name
@@ -125,8 +125,8 @@ public class User extends Resource {
      * Gets the components of the User's real name.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
      * </p>
      *
      * @return the real {@link Name} of the {@link User}
@@ -139,8 +139,8 @@ public class User extends Resource {
      * Gets the name of the User, suitable for display to end-users.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
      * </p>
      *
      * @return the display name of the {@link User}
@@ -153,8 +153,8 @@ public class User extends Resource {
      * Gets the casual way to address the user in real life,
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
      * </p>
      *
      * @return the nickname of the {@link User}
@@ -167,8 +167,8 @@ public class User extends Resource {
      * Gets a fully qualified URL to a page representing the User's online profile.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
      * </p>
      *
      * @return the progile URL of the {@link User}
@@ -190,8 +190,8 @@ public class User extends Resource {
      * Gets the type of the {@link User}
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
      * </p>
      *
      * @return the type of the {@link User}
@@ -204,8 +204,8 @@ public class User extends Resource {
      * Gets the preferred written or spoken language of the User in ISO 3166-1 alpha 2 format, e.g. "DE" or "US".
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
      * </p>
      *
      * @return the preferred language of the {@link User}
@@ -218,8 +218,8 @@ public class User extends Resource {
      * Gets the default location of the User in ISO 639-1 two letter language code, e.g. 'de_DE' or 'en_US'
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
      * </p>
      *
      * @return the default location of the {@link User}
@@ -232,8 +232,8 @@ public class User extends Resource {
      * Gets the User's time zone in the "Olson" timezone database format
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
      * </p>
      *
      * @return the time zone of the {@link User}
@@ -246,8 +246,8 @@ public class User extends Resource {
      * Gets a Boolean that indicates the User's administrative status.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
      * </p>
      *
      * @return the active status of the {@link User}
@@ -260,8 +260,8 @@ public class User extends Resource {
      * Gets the password from the User.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
      * </p>
      *
      * <p>
@@ -278,8 +278,8 @@ public class User extends Resource {
      * Gets all E-mail addresses for the User.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
      * 6.2</a>
      * </p>
      *
@@ -293,8 +293,8 @@ public class User extends Resource {
      * Gets the phone numbers for the user.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
      * 6.2</a>
      * </p>
      *
@@ -308,8 +308,8 @@ public class User extends Resource {
      * Gets the instant messaging address for the user.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
      * 6.2</a>
      * </p>
      *
@@ -323,8 +323,8 @@ public class User extends Resource {
      * Gets the URL's of the photos of the user.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
      * 6.2</a>
      * </p>
      *
@@ -338,8 +338,8 @@ public class User extends Resource {
      * Gets the physical mailing addresses for this user.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
      * 6.2</a>
      * </p>
      *
@@ -353,8 +353,8 @@ public class User extends Resource {
      * Gets a list of groups that the user belongs to.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
      * 6.2</a>
      * </p>
      *
@@ -368,8 +368,8 @@ public class User extends Resource {
      * Gets a list of entitlements for the user that represent a thing the User has.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
      * 6.2</a>
      * </p>
      *
@@ -383,8 +383,8 @@ public class User extends Resource {
      * Gets a list of roles for the user that collectively represent who the User is e.g., 'Student', "Faculty"
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
      * 6.2</a>
      * </p>
      *
@@ -398,8 +398,8 @@ public class User extends Resource {
      * Gets a list of certificates issued to the user. Values are Binary and DER encoded x509.
      *
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0, section
      * 6.2</a>
      * </p>
      *
@@ -1209,7 +1209,12 @@ public class User extends Resource {
             return this;
         }
 
+        /**
+         * @deprecated Don't use this method - let the extensions add their schema themselves. Will be removed in
+         *             version 1.8 or 2.0
+         */
         @Override
+        @Deprecated
         public Builder setSchemas(Set<String> schemas) {
             super.setSchemas(schemas);
             return this;

--- a/src/test/groovy/org/osiam/resources/scim/GroupSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/GroupSpec.groovy
@@ -31,18 +31,17 @@ class GroupSpec extends Specification {
 
     def 'should be able to generate a group'() {
         given:
-        
+
         User user = new User.Builder('userName').setId('some ID').build()
-        
+
         MemberRef memberRef = new MemberRef.Builder(user).build()
-        
+
         Meta meta = new Meta.Builder().build()
-        
+
         Group.Builder builder = new Group.Builder('display')
                 .setExternalId('externalId')
                 .setId('id')
                 .setMeta(meta)
-                .setSchemas(['schema'] as Set)
                 .setMembers([memberRef] as Set)
 
         when:
@@ -52,7 +51,7 @@ class GroupSpec extends Specification {
         group.members.iterator().next().value == memberRef.value
         group.displayName == 'display'
         group.externalId == 'externalId'
-        group.schemas.first() == 'schema'
+        group.schemas.first() == Constants.GROUP_CORE_SCHEMA
         group.id == 'id'
     }
 
@@ -105,16 +104,16 @@ class GroupSpec extends Specification {
         then:
         thrown(SCIMDataValidationException)
     }
-    
+
     def 'the copied group should have the given displayname'(){
         given:
         Group oldGroup = new Group.Builder("oldDisplayName").setExternalId("externalId").build()
         String newDisplayName = 'newDisplayName'
         Group newGroup
-        
+
         when:
         newGroup = new Group.Builder(newDisplayName, oldGroup).build()
-        
+
         then:
         newGroup.getExternalId() == 'externalId'
         newGroup.getDisplayName() == newDisplayName

--- a/src/test/groovy/org/osiam/resources/scim/UserJsonSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/UserJsonSpec.groovy
@@ -45,7 +45,6 @@ class UserJsonSpec extends Specification {
                 .setMeta(new Meta.Builder()
                         .setLocation('https://example.com/v1/Users/2819c223...')
                         .setResourceType('User').build())
-                .setSchemas(['urn:scim:schemas:core:2.0:User'] as Set)
                 .setExternalId('bjensen')
                 .setName(new Name.Builder()
                         .setFormatted('Ms. Barbara J Jensen III')

--- a/src/test/groovy/org/osiam/resources/scim/UserSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/UserSpec.groovy
@@ -23,6 +23,8 @@
 
 package org.osiam.resources.scim
 
+import com.sun.corba.se.impl.orbutil.closure.Constant
+
 import java.util.ArrayList
 import java.util.HashMap
 import java.util.List
@@ -60,11 +62,11 @@ class UserSpec extends Specification {
     }
 
     def 'should be able to contain schemas'() {
-        def schemas = ['urn:wtf', 'urn:hajo'] as Set
         when:
-        User user = new User.Builder('username').setSchemas(schemas).build()
+        User user = new User.Builder('username').build()
+
         then:
-        user.schemas == schemas
+        user.schemas[0] == Constants.USER_CORE_SCHEMA
     }
 
     @Unroll
@@ -114,7 +116,6 @@ class UserSpec extends Specification {
                 .addRoles([role] as List)
                 .setTimezone('MEZ')
                 .setTitle('title')
-                .setSchemas(['schema'] as Set)
                 .addX509Certificates([x509Certificat] as List)
                 .setMeta(meta)
                 .setUserType('userType')
@@ -147,7 +148,7 @@ class UserSpec extends Specification {
         user.id == 'id'
         user.meta == meta
         user.externalId == 'externalId'
-        user.schemas.first() == 'schema'
+        user.schemas.containsAll([Constants.USER_CORE_SCHEMA,'extension'])
         user.getExtensions().get('extension').getField('gender', ExtensionFieldType.STRING) == extension.getField('gender', ExtensionFieldType.STRING)
     }
 
@@ -292,16 +293,16 @@ class UserSpec extends Specification {
         then:
         thrown(IllegalArgumentException)
     }
-    
+
     def 'the copied user should have the given username'(){
         given:
         User oldUser = new User.Builder("oldUserName").setActive(true).build()
         String newUserName = 'newUserName'
         User newUser
-        
+
         when:
         newUser = new User.Builder(newUserName, oldUser).build()
-        
+
         then:
         newUser.isActive() == true
         newUser.getUserName() == newUserName


### PR DESCRIPTION
Setting the schemata is totally senseless. If no extensions are involved,
then adding another schema or even overwrite the core schemata, would
mean you have a different resource, i.e. not a `User` but an
`EnterpriseUser`, which is not possible, without adding new fields, etc.
to the existing classes. If extensions are involved, then adding the
extension will automatically add the URN to the list of schemata.

This commit deprecates these methods, including a hint, that
they will be finally removed in version 1.8 or 2.0. Three versions
should be enough for users to update. Hopefully, nobody is using the
method anyway.

Resolves #127