### PR TITLE
Make User and Group Serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Remove unused meta classes and package
 - Deprecate User/Group/Resource#setSchemas(...)
 - Update schema URNs to SCIM draft 19
+- Make User and Group serializable
 
 ## 1.4 - 2015-06-17
 

--- a/src/main/java/org/osiam/resources/scim/Address.java
+++ b/src/main/java/org/osiam/resources/scim/Address.java
@@ -26,6 +26,8 @@ package org.osiam.resources.scim;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+import java.io.Serializable;
+
 /**
  * A physical mailing address for a User
  * <p>
@@ -34,7 +36,9 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
  * </p>
  */
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
-public class Address extends MultiValuedAttribute { // NOSONAR - Builder constructs instances of this class
+public class Address extends MultiValuedAttribute implements Serializable { // NOSONAR - Builder constructs instances of this class
+
+    private static final long serialVersionUID = 2731087785568277294L;
 
     private String formatted;
     private String streetAddress;

--- a/src/main/java/org/osiam/resources/scim/Email.java
+++ b/src/main/java/org/osiam/resources/scim/Email.java
@@ -22,6 +22,7 @@
  */
 package org.osiam.resources.scim;
 
+import java.io.Serializable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -37,7 +38,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2">SCIM core schema 2.0, section 3.2</a>
  * </p>
  */
-public class Email extends MultiValuedAttribute {
+public class Email extends MultiValuedAttribute implements Serializable {
+
+    private static final long serialVersionUID = 5595340465249831012L;
 
     @JsonProperty
     private Type type;

--- a/src/main/java/org/osiam/resources/scim/Entitlement.java
+++ b/src/main/java/org/osiam/resources/scim/Entitlement.java
@@ -24,6 +24,8 @@ package org.osiam.resources.scim;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
+
 /**
  * This class represents a entitlement attribute.
  * 
@@ -32,7 +34,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2">SCIM core schema 2.0, section 3.2</a>
  * </p>
  */
-public class Entitlement extends MultiValuedAttribute {
+public class Entitlement extends MultiValuedAttribute implements Serializable {
+
+    private static final long serialVersionUID = -1630551919515647349L;
 
     @JsonProperty
     private Type type;

--- a/src/main/java/org/osiam/resources/scim/Extension.java
+++ b/src/main/java/org/osiam/resources/scim/Extension.java
@@ -1,5 +1,6 @@
 package org.osiam.resources.scim;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 /*
  * Copyright (C) 2013 tarent AG
@@ -47,7 +48,9 @@ import com.google.common.collect.ImmutableMap;
  * </p>
  */
 @JsonSerialize(using = ExtensionSerializer.class)
-public class Extension {
+public class Extension implements Serializable {
+
+    private static final long serialVersionUID = -121658804932369438L;
 
     @JsonIgnore
     private String urn;
@@ -467,7 +470,10 @@ public class Extension {
     /**
      * This class represents a field of an extension with its type and value. Instances of this class are immutable.
      */
-    public static final class Field {
+    public static final class Field implements Serializable {
+
+        private static final long serialVersionUID = 5733905110534921573L;
+
         private final ExtensionFieldType<?> type;
         private final String value;
 

--- a/src/main/java/org/osiam/resources/scim/ExtensionFieldType.java
+++ b/src/main/java/org/osiam/resources/scim/ExtensionFieldType.java
@@ -25,6 +25,10 @@ package org.osiam.resources.scim;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
@@ -44,7 +48,9 @@ import com.google.common.io.BaseEncoding;
  * @param <T>
  *            the actual type this {@link ExtensionFieldType} represents
  */
-public abstract class ExtensionFieldType<T> {
+public abstract class ExtensionFieldType<T> implements Serializable {
+
+    private static final long serialVersionUID = 5665143978696725609L;
 
     private String name;
 
@@ -205,13 +211,17 @@ public abstract class ExtensionFieldType<T> {
     };
 
     /**
+     * Since this field can not be serialized, it will be created when the object is de-serialized (see readObject()).
+     */
+    private static DateTimeFormatter dateTimeFormatter = ISODateTimeFormat.dateTime().withZoneUTC();
+
+    /**
      * ExtensionFieldType for the Scim type DateTime (actual type is {@link Date}). Valid values are in ISO
      * DateTimeFormat with the timeZone UTC like '2011-08-01T18:29:49.000Z'
      */
     public static final ExtensionFieldType<Date> DATE_TIME = new ExtensionFieldType<Date>("DATE_TIME") { // NOSONAR -
         // it is ok if the inner class is over 20 characters long
 
-        private DateTimeFormatter dateTimeFormatter = ISODateTimeFormat.dateTime().withZoneUTC();
 
         @Override
         public Date fromString(String stringValue) {
@@ -292,5 +302,4 @@ public abstract class ExtensionFieldType<T> {
     protected void ensureValueIsNotNull(Object value) {
         checkArgument(value != null, "The given value cannot be null.");
     }
-
 }

--- a/src/main/java/org/osiam/resources/scim/Group.java
+++ b/src/main/java/org/osiam/resources/scim/Group.java
@@ -23,6 +23,7 @@
 
 package org.osiam.resources.scim;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -47,7 +48,9 @@ import com.google.common.base.Strings;
  * </p>
  */
 @JsonInclude(Include.NON_EMPTY)
-public class Group extends Resource {
+public class Group extends Resource implements Serializable {
+
+    private static final long serialVersionUID = -2995603177584656028L;
 
     private String displayName;
     private Set<MemberRef> members = new HashSet<>();

--- a/src/main/java/org/osiam/resources/scim/GroupRef.java
+++ b/src/main/java/org/osiam/resources/scim/GroupRef.java
@@ -24,6 +24,8 @@ package org.osiam.resources.scim;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
+
 /**
  * This class represents a Reference of a Group
  * 
@@ -32,7 +34,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2">SCIM core schema 2.0, section 3.2</a>
  * </p>
  */
-public class GroupRef extends MultiValuedAttribute {
+public class GroupRef extends MultiValuedAttribute implements Serializable {
+
+    private static final long serialVersionUID = -3765452569557089013L;
 
     @JsonProperty
     private Type type;

--- a/src/main/java/org/osiam/resources/scim/Im.java
+++ b/src/main/java/org/osiam/resources/scim/Im.java
@@ -24,6 +24,8 @@ package org.osiam.resources.scim;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
+
 /**
  * This class represents a Im attribute.
  * 
@@ -32,7 +34,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2">SCIM core schema 2.0, section 3.2</a>
  * </p>
  */
-public class Im extends MultiValuedAttribute {
+public class Im extends MultiValuedAttribute implements Serializable {
+
+    private static final long serialVersionUID = -6629213491428871065L;
 
     @JsonProperty
     private Type type;

--- a/src/main/java/org/osiam/resources/scim/MemberRef.java
+++ b/src/main/java/org/osiam/resources/scim/MemberRef.java
@@ -23,6 +23,8 @@
 
 package org.osiam.resources.scim;
 
+import java.io.Serializable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -30,11 +32,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * This class represents a {@link User} or a {@link Group} which are members of an actual {@link Group}
  * 
  * <p>
- * For more detailed information please look at the <a
- * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-8">SCIM core schema 2.0, sections 8</a>
+ * For more detailed information please look at the
+ * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-8">SCIM core schema 2.0, sections 8</a>
  * </p>
  */
-public class MemberRef extends MultiValuedAttribute { // NOSONAR - will be constructed by the builder or jackson
+public class MemberRef extends MultiValuedAttribute implements Serializable { // NOSONAR - will be constructed by the
+                                                                              // builder or jackson
+
+    private static final long serialVersionUID = 2965422671682767189L;
 
     @JsonProperty
     private Type type;
@@ -72,14 +77,15 @@ public class MemberRef extends MultiValuedAttribute { // NOSONAR - will be const
 
     /**
      * Gets the type of the attribute.
-     * 
+     *
      * <p>
-     * For more detailed information please look at the <a href=
-     * "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2" >SCIM core schema 2.0, section 3.2</a>
+     * For more detailed information please look at the
+     * <a href= "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2" >SCIM core schema 2.0, section
+     * 3.2</a>
      * </p>
-     * 
+     *
      * @return
-     * 
+     *
      * @return the actual type
      */
     public Type getType() {
@@ -118,7 +124,8 @@ public class MemberRef extends MultiValuedAttribute { // NOSONAR - will be const
 
     @Override
     public String toString() {
-        return "MemberRef [display=" + getDisplay() +", value=" + getValue() + ", type=" + type + ", primary=" + isPrimary() 
+        return "MemberRef [display=" + getDisplay() + ", value=" + getValue() + ", type=" + type + ", primary="
+                + isPrimary()
                 + ", operation=" + getOperation() + ", ref=" + getReference() + "]";
     }
 
@@ -134,7 +141,7 @@ public class MemberRef extends MultiValuedAttribute { // NOSONAR - will be const
 
         /**
          * builds an Builder based of the given Attribute
-         * 
+         *
          * @param member
          *        existing Attribute
          */
@@ -142,15 +149,15 @@ public class MemberRef extends MultiValuedAttribute { // NOSONAR - will be const
             super(member);
             type = member.type;
         }
-        
+
         /**
          * builds an Builder based of the given {@link User} or {@link Group}
-         * 
+         *
          * @param resource
          *        existing {@link User} or {@link Group}
          */
         public Builder(Resource resource) {
-        	setValue(resource.getId());
+            setValue(resource.getId());
         }
 
         @Override

--- a/src/main/java/org/osiam/resources/scim/Meta.java
+++ b/src/main/java/org/osiam/resources/scim/Meta.java
@@ -23,6 +23,7 @@
 
 package org.osiam.resources.scim;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -33,14 +34,16 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * This class represents the meta data of a resource.
- * 
+ * <p/>
  * <p>
  * For more detailed information please look at the <a
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02">SCIM core schema 2.0</a>
  * </p>
  */
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
-public class Meta {
+public class Meta implements Serializable {
+
+    private static final long serialVersionUID = -4536271487921469946L;
 
     @JsonSerialize(using = JsonDateSerializer.class)
     private Date created;
@@ -68,12 +71,12 @@ public class Meta {
 
     /**
      * Gets the URI of the Resource being returned.
-     * 
+     * <p/>
      * <p>
      * For more detailed information please look at the <a
      * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-5">SCIM core schema 2.0, section 5</a>
      * </p>
-     * 
+     *
      * @return the location
      */
     public String getLocation() {
@@ -82,12 +85,12 @@ public class Meta {
 
     /**
      * Gets the version of the Resource being returned.
-     * 
+     * <p/>
      * <p>
      * For more detailed information please look at the <a
      * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-5">SCIM core schema 2.0, section 5</a>
      * </p>
-     * 
+     *
      * @return the version
      */
     public String getVersion() {
@@ -96,12 +99,12 @@ public class Meta {
 
     /**
      * Gets the attributes to be deleted from the Resource
-     * 
+     * <p/>
      * <p>
      * For more detailed information please look at the <a
      * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-5">SCIM core schema 2.0, section 5</a>
      * </p>
-     * 
+     *
      * @return a set of attributes to be deleted
      */
     public Set<String> getAttributes() {
@@ -110,7 +113,7 @@ public class Meta {
 
     /**
      * Gets the date when the {@link Resource} was created
-     * 
+     *
      * @return the creation date
      */
     public Date getCreated() {
@@ -122,7 +125,7 @@ public class Meta {
 
     /**
      * Gets the date when the {@link Resource} was last modified
-     * 
+     *
      * @return the last modified date
      */
     public Date getLastModified() {
@@ -134,7 +137,7 @@ public class Meta {
 
     /**
      * Gets the type of the Resource (User or Group)
-     * 
+     *
      * @return the type of the actual resource
      */
     public String getResourceType() {
@@ -171,9 +174,8 @@ public class Meta {
 
         /**
          * Constructs a new builder with the created and last modified time set to the given values
-         * 
-         * @param meta
-         *            the meta object to copy from
+         *
+         * @param meta the meta object to copy from
          */
         public Builder(Meta meta) {
             if (meta == null) {
@@ -189,9 +191,8 @@ public class Meta {
 
         /**
          * Set the location (See {@link Meta#getLocation()}).
-         * 
-         * @param location
-         *            the resource uri
+         *
+         * @param location the resource uri
          * @return the builder itself
          */
         public Builder setLocation(String location) {
@@ -201,9 +202,8 @@ public class Meta {
 
         /**
          * Sets the version of the Resource (See {@link Meta#getVersion()}).
-         * 
-         * @param version
-         *            the version of the resource
+         *
+         * @param version the version of the resource
          * @return the builder itself
          */
         public Builder setVersion(String version) {
@@ -213,9 +213,8 @@ public class Meta {
 
         /**
          * Sets the type of the Resource (See {@link Meta#getResourceType()}).
-         * 
-         * @param resourceType
-         *            the type
+         *
+         * @param resourceType the type
          * @return the builder itself
          */
         public Builder setResourceType(String resourceType) {
@@ -225,9 +224,8 @@ public class Meta {
 
         /**
          * Sets the names of the attributes to be removed from the Resource.
-         * 
-         * @param attributes
-         *            name of attributes to be deleted
+         *
+         * @param attributes name of attributes to be deleted
          * @return the builder itself
          */
         public Builder setAttributes(Set<String> attributes) {
@@ -237,7 +235,7 @@ public class Meta {
 
         /**
          * Builds a Meta Object with the given parameters
-         * 
+         *
          * @return a new Meta Object
          */
         public Meta build() {

--- a/src/main/java/org/osiam/resources/scim/MultiValuedAttribute.java
+++ b/src/main/java/org/osiam/resources/scim/MultiValuedAttribute.java
@@ -23,6 +23,8 @@
 
 package org.osiam.resources.scim;
 
+import java.io.Serializable;
+
 import org.osiam.resources.exception.SCIMDataValidationException;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -34,12 +36,15 @@ import com.google.common.base.Strings;
  * This class represents a multi valued attribute.
  * 
  * <p>
- * For more detailed information please look at the <a href=
- * "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2">SCIM core schema 2.0, section 3.2</a>
+ * For more detailed information please look at the
+ * <a href= "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2">SCIM core schema 2.0, section
+ * 3.2</a>
  * </p>
  */
 @JsonInclude(Include.NON_EMPTY)
-public abstract class MultiValuedAttribute {
+public abstract class MultiValuedAttribute implements Serializable {
+
+    private static final long serialVersionUID = 5910207539638462247L;
 
     private String operation;
     private String value;
@@ -66,8 +71,9 @@ public abstract class MultiValuedAttribute {
      * Gets the attribute's significant value; e.g., the e-mail address, phone number etc.
      * 
      * <p>
-     * For more detailed information please look at the <a href=
-     * "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2" >SCIM core schema 2.0, section 3.2</a>
+     * For more detailed information please look at the
+     * <a href= "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2" >SCIM core schema 2.0, section
+     * 3.2</a>
      * </p>
      * 
      * @return the value of the actual multi value attribute
@@ -80,8 +86,9 @@ public abstract class MultiValuedAttribute {
      * Gets the human readable name, primarily used for display purposes.
      * 
      * <p>
-     * For more detailed information please look at the <a href=
-     * "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2" >SCIM core schema 2.0, section 3.2</a>
+     * For more detailed information please look at the
+     * <a href= "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2" >SCIM core schema 2.0, section
+     * 3.2</a>
      * </p>
      * 
      * @return the display attribute
@@ -94,8 +101,9 @@ public abstract class MultiValuedAttribute {
      * Gets a Boolean value indicating the 'primary' or preferred attribute value for this attribute.
      * 
      * <p>
-     * For more detailed information please look at the <a href=
-     * "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2" >SCIM core schema 2.0, section 3.2</a>
+     * For more detailed information please look at the
+     * <a href= "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2" >SCIM core schema 2.0, section
+     * 3.2</a>
      * </p>
      * 
      * @return the primary attribute
@@ -108,8 +116,9 @@ public abstract class MultiValuedAttribute {
      * Gets the operation applied during a PATCH request.
      * 
      * <p>
-     * For more detailed information please look at the <a href=
-     * "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2" >SCIM core schema 2.0, section 3.2</a>
+     * For more detailed information please look at the
+     * <a href= "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2" >SCIM core schema 2.0, section
+     * 3.2</a>
      * </p>
      * 
      * @return the operation
@@ -122,8 +131,9 @@ public abstract class MultiValuedAttribute {
      * Gets the reference to the actual SCIM Resource.
      * 
      * <p>
-     * For more detailed information please look at the <a
-     * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-8">SCIM core schema 2.0, sections 8</a>
+     * For more detailed information please look at the
+     * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-8">SCIM core schema 2.0, sections
+     * 8</a>
      * </p>
      * 
      * @return the reference of the actual resource
@@ -228,7 +238,7 @@ public abstract class MultiValuedAttribute {
          * @return the builder itself
          */
         protected Builder setValue(String value) {
-            if(Strings.isNullOrEmpty(value)){
+            if (Strings.isNullOrEmpty(value)) {
                 throw new SCIMDataValidationException("The given value can't be null or empty.");
             }
             this.value = value;
@@ -239,10 +249,10 @@ public abstract class MultiValuedAttribute {
          * Sets the human readable name (See {@link MultiValuedAttribute#getDisplay()}).
          * 
          * <p>
-         * client info: the Display value is set by the OSIAM server.
-         * If a MultiValuedAttribute which is send to the OSIAM server has this value filled, 
-         * the value will be ignored or the action will be rejected. 
+         * client info: the Display value is set by the OSIAM server. If a MultiValuedAttribute which is send to the
+         * OSIAM server has this value filled, the value will be ignored or the action will be rejected.
          * </p>
+         * 
          * @param display
          *        a human readable name
          * @return the builder itself
@@ -282,9 +292,8 @@ public abstract class MultiValuedAttribute {
          * Sets the reference (See {@link MemberRef#getReference()}).
          * 
          * <p>
-         * client info: the Reference value is set by the OSIAM server.
-         * If a MultiValuedAttribute which is send to the OSIAM server has this value filled, 
-         * the value will be ignored or the action will be rejected. 
+         * client info: the Reference value is set by the OSIAM server. If a MultiValuedAttribute which is send to the
+         * OSIAM server has this value filled, the value will be ignored or the action will be rejected.
          * </p>
          * 
          * @param reference

--- a/src/main/java/org/osiam/resources/scim/MultiValuedAttributeType.java
+++ b/src/main/java/org/osiam/resources/scim/MultiValuedAttributeType.java
@@ -25,7 +25,11 @@ package org.osiam.resources.scim;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Strings;
 
-public abstract class MultiValuedAttributeType {
+import java.io.Serializable;
+
+public abstract class MultiValuedAttributeType implements Serializable {
+
+    private static final long serialVersionUID = 8664817830929663977L;
 
     private final String value;
 

--- a/src/main/java/org/osiam/resources/scim/Name.java
+++ b/src/main/java/org/osiam/resources/scim/Name.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Strings;
 
+import java.io.Serializable;
+
 /**
  * This class represents the User's real name.
  *
@@ -36,7 +38,9 @@ import com.google.common.base.Strings;
  * </p>
  */
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
-public class Name {
+public class Name implements Serializable {
+
+    private static final long serialVersionUID = -2090787512643160922L;
 
     private String formatted;
     private String familyName;

--- a/src/main/java/org/osiam/resources/scim/PhoneNumber.java
+++ b/src/main/java/org/osiam/resources/scim/PhoneNumber.java
@@ -24,6 +24,8 @@ package org.osiam.resources.scim;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
+
 /**
  * This class represents a phoneNumber attribute.
  * 
@@ -32,7 +34,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2">SCIM core schema 2.0, section 3.2</a>
  * </p>
  */
-public class PhoneNumber extends MultiValuedAttribute {
+public class PhoneNumber extends MultiValuedAttribute implements Serializable {
+
+    private static final long serialVersionUID = -511746669960696470L;
 
     @JsonProperty
     private Type type;

--- a/src/main/java/org/osiam/resources/scim/Photo.java
+++ b/src/main/java/org/osiam/resources/scim/Photo.java
@@ -22,6 +22,7 @@
  */
 package org.osiam.resources.scim;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -43,7 +44,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * </p>
  */
 @JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE)
-public class Photo extends MultiValuedAttribute {
+public class Photo extends MultiValuedAttribute implements Serializable {
+
+    private static final long serialVersionUID = -3801047382575408796L;
 
     @JsonProperty
     private Type type;

--- a/src/main/java/org/osiam/resources/scim/Resource.java
+++ b/src/main/java/org/osiam/resources/scim/Resource.java
@@ -23,6 +23,7 @@
 
 package org.osiam.resources.scim;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -31,7 +32,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * This class represents a SCIM Resource and is the base class for {@link User}s and {@link Group}s.
  */
-public abstract class Resource {
+public abstract class Resource implements Serializable {
+
+    private static final long serialVersionUID = 1726103518645055449L;
 
     private String id;
     private String externalId;

--- a/src/main/java/org/osiam/resources/scim/Role.java
+++ b/src/main/java/org/osiam/resources/scim/Role.java
@@ -22,6 +22,8 @@
  */
 package org.osiam.resources.scim;
 
+import java.io.Serializable;
+
 /**
  * This class represents a role attribute.
  * 
@@ -30,7 +32,9 @@ package org.osiam.resources.scim;
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2">SCIM core schema 2.0, section 3.2</a>
  * </p>
  */
-public class Role extends MultiValuedAttribute {
+public class Role extends MultiValuedAttribute implements Serializable {
+
+    private static final long serialVersionUID = -4086224449976544553L;
 
     private Type type;
 

--- a/src/main/java/org/osiam/resources/scim/User.java
+++ b/src/main/java/org/osiam/resources/scim/User.java
@@ -23,6 +23,7 @@
 
 package org.osiam.resources.scim;
 
+import java.io.Serializable;
 import java.util.*;
 
 import org.osiam.resources.exception.SCIMDataValidationException;
@@ -49,7 +50,9 @@ import com.google.common.base.Strings;
  * </p>
  */
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
-public class User extends Resource {
+public class User extends Resource implements Serializable {
+
+    private static final long serialVersionUID = -4076516708797425414L;
 
     private String userName;
     private Name name;

--- a/src/main/java/org/osiam/resources/scim/X509Certificate.java
+++ b/src/main/java/org/osiam/resources/scim/X509Certificate.java
@@ -22,6 +22,8 @@
  */
 package org.osiam.resources.scim;
 
+import java.io.Serializable;
+
 /**
  * This class represents a x509Certificate attribute.
  * 
@@ -30,7 +32,9 @@ package org.osiam.resources.scim;
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2">SCIM core schema 2.0, section 3.2</a>
  * </p>
  */
-public class X509Certificate extends MultiValuedAttribute {
+public class X509Certificate extends MultiValuedAttribute implements Serializable {
+
+    private static final long serialVersionUID = 4858483299981855173L;
 
     private Type type;
 

--- a/src/test/groovy/org/osiam/resources/scim/GroupSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/GroupSpec.groovy
@@ -23,8 +23,8 @@
 
 package org.osiam.resources.scim
 
+import org.apache.commons.lang3.SerializationUtils
 import org.osiam.resources.exception.SCIMDataValidationException
-
 import spock.lang.Specification
 
 class GroupSpec extends Specification {
@@ -105,7 +105,7 @@ class GroupSpec extends Specification {
         thrown(SCIMDataValidationException)
     }
 
-    def 'the copied group should have the given displayname'(){
+    def 'the copied group should have the given displayname'() {
         given:
         Group oldGroup = new Group.Builder("oldDisplayName").setExternalId("externalId").build()
         String newDisplayName = 'newDisplayName'
@@ -119,4 +119,27 @@ class GroupSpec extends Specification {
         newGroup.getDisplayName() == newDisplayName
     }
 
+    def 'group can be serialized and deserialized'() {
+        given:
+        User user = new User.Builder('userName').setId('some ID').build()
+        MemberRef memberRef = new MemberRef.Builder(user).build()
+        Meta meta = new Meta.Builder().build()
+
+        Group.Builder builder = new Group.Builder('display')
+                .setExternalId('externalId')
+                .setId('id')
+                .setMeta(meta)
+                .setMembers([memberRef] as Set)
+
+        Group group = builder.build()
+
+        when:
+        def newGroup = (Group) SerializationUtils.deserialize(SerializationUtils.serialize(group))
+
+        then:
+        group == newGroup
+        group.getExternalId() == newGroup.getExternalId()
+        group.getMeta() == newGroup.getMeta()
+        group.getMembers().getAt(0) == newGroup.getMembers().getAt(0)
+    }
 }


### PR DESCRIPTION
Fixes #129

The classes implement the interface `Serializable` and have a
`serialVersionUID` field.

A test for each of the classes tests that no exception is thrown when
serializing and deserializing the object, and that the deserialized is
equal to the original.