### PR TITLE
Deprecate all constants from Constants interface

### DIFF
--- a/src/main/java/org/osiam/resources/scim/Constants.java
+++ b/src/main/java/org/osiam/resources/scim/Constants.java
@@ -44,6 +44,12 @@ public interface Constants {
      * @deprecated please use {@link SCIMSearchResult}.SCHEMA
      */
     String LIST_RESPONSE_CORE_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
+    /**
+     * @deprecated  This constant is going to be removed soon.
+     */
     String SERVICE_PROVIDER_CORE_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig";
+    /**
+     * @deprecated  This constant is going to be removed soon.
+     */
     int MAX_RESULT = 100;
 }


### PR DESCRIPTION
After merging PR #150 we agreed that all constants should get annotations and  javadoc that declares them deprecated. this pr fixes that.