### PR TITLE
Move error response to scim schema

### DIFF
--- a/src/main/java/org/osiam/resources/scim/ErrorResponse.java
+++ b/src/main/java/org/osiam/resources/scim/ErrorResponse.java
@@ -1,0 +1,30 @@
+package org.osiam.resources.scim;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.util.Arrays;
+
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+public class ErrorResponse {
+    public static final String ERROR_URN = "urn:ietf:params:scim:api:messages:2.0:Error";
+    private String[] schemas = {ERROR_URN};
+    private String status;
+    private String detail;
+
+    public ErrorResponse(int statusCode, String message) {
+        status = Integer.toString(statusCode);
+        detail = message;
+    }
+
+    public String[] getSchemas() {
+        return Arrays.copyOf(schemas, schemas.length);
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+}


### PR DESCRIPTION
The scim schema specification specifies the error response object. It's
representation should be part of the scim-schema.