### PR TITLE
Replace the deprecated JsonSerialize.Inclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.5.3</version>
+            <version>2.5.4</version>
         </dependency>
 
         <!-- Used to convert ISO DateTime Strings to Date and vice versa (APACHE 2 License) -->

--- a/src/main/java/org/osiam/resources/scim/Address.java
+++ b/src/main/java/org/osiam/resources/scim/Address.java
@@ -23,8 +23,8 @@
 
 package org.osiam.resources.scim;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.io.Serializable;
 
@@ -35,7 +35,7 @@ import java.io.Serializable;
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6.2">SCIM core schema 2.0</a>
  * </p>
  */
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Address extends MultiValuedAttribute implements Serializable { // NOSONAR - Builder constructs instances of this class
 
     private static final long serialVersionUID = 2731087785568277294L;
@@ -68,7 +68,7 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
     /**
      * Gets the full mailing address, formatted for display or use with a mailing label.
-     * 
+     *
      * @return the formatted address
      */
     public String getFormatted() {
@@ -77,7 +77,7 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
     /**
      * Gets the full street address, which may include house number, street name, etc.
-     * 
+     *
      * @return the street address
      */
     public String getStreetAddress() {
@@ -86,7 +86,7 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
     /**
      * Gets the city or locality
-     * 
+     *
      * @return the city or locality
      */
     public String getLocality() {
@@ -95,7 +95,7 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
     /**
      * Gets the state or region
-     * 
+     *
      * @return region the region
      */
     public String getRegion() {
@@ -104,7 +104,7 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
     /**
      * Gets the postal code
-     * 
+     *
      * @return postalCode the postal code
      */
     public String getPostalCode() {
@@ -113,7 +113,7 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
     /**
      * Gets the country name in ISO 3166-1 alpha 2 format, e.g. "DE" or "US".
-     * 
+     *
      * @return the country
      */
     public String getCountry() {
@@ -122,14 +122,12 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
     /**
      * Gets the type of the attribute.
-     * 
+     * <p/>
      * <p>
      * For more detailed information please look at the <a href=
      * "http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-3.2" >SCIM core schema 2.0, section 3.2</a>
      * </p>
-     * 
-     * @return
-     * 
+     *
      * @return the actual type
      */
     public Type getType() {
@@ -249,9 +247,8 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
         /**
          * builds an Builder based of the given Attribute
-         * 
-         * @param address
-         *        existing Attribute
+         *
+         * @param address existing Attribute
          */
         public Builder(Address address) {
             super(address);
@@ -266,10 +263,8 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
         /**
          * Sets the full mailing address (See {@link Address#getFormatted()}).
-         * 
-         * @param formatted
-         *        the formatted address
-         * 
+         *
+         * @param formatted the formatted address
          * @return the builder itself
          */
         public Builder setFormatted(String formatted) {
@@ -279,10 +274,8 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
         /**
          * Sets the full street address component, (See {@link Address#getStreetAddress()}).
-         * 
-         * @param streetAddress
-         *        the street address
-         * 
+         *
+         * @param streetAddress the street address
          * @return the builder itself
          */
         public Builder setStreetAddress(String streetAddress) {
@@ -292,10 +285,8 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
         /**
          * Sets the city or locality.
-         * 
-         * @param locality
-         *        the locality
-         * 
+         *
+         * @param locality the locality
          * @return the builder itself
          */
         public Builder setLocality(String locality) {
@@ -305,10 +296,8 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
         /**
          * Sets the state or region.
-         * 
-         * @param region
-         *        the region
-         * 
+         *
+         * @param region the region
          * @return the builder itself
          */
         public Builder setRegion(String region) {
@@ -318,10 +307,8 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
         /**
          * Sets the postal code
-         * 
-         * @param postalCode
-         *        the postal code
-         * 
+         *
+         * @param postalCode the postal code
          * @return the builder itself
          */
         public Builder setPostalCode(String postalCode) {
@@ -331,9 +318,8 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
         /**
          * Sets the label indicating the attribute's function (See {@link MultiValuedAttribute#getType()}).
-         * 
-         * @param type
-         *        the type of the attribute
+         *
+         * @param type the type of the attribute
          * @return the builder itself
          */
         public Builder setType(Type type) {
@@ -343,10 +329,8 @@ public class Address extends MultiValuedAttribute implements Serializable { // N
 
         /**
          * Sets the country name (See {@link Address#getCountry()}).
-         * 
-         * @param country
-         *        the country
-         * 
+         *
+         * @param country the country
          * @return the builder itself
          */
         public Builder setCountry(String country) {

--- a/src/main/java/org/osiam/resources/scim/ErrorResponse.java
+++ b/src/main/java/org/osiam/resources/scim/ErrorResponse.java
@@ -1,12 +1,11 @@
 package org.osiam.resources.scim;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.util.Arrays;
 
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ErrorResponse {
     public static final String ERROR_URN = "urn:ietf:params:scim:api:messages:2.0:Error";
     private String[] schemas = {ERROR_URN};

--- a/src/main/java/org/osiam/resources/scim/Meta.java
+++ b/src/main/java/org/osiam/resources/scim/Meta.java
@@ -23,14 +23,14 @@
 
 package org.osiam.resources.scim;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.osiam.resources.helper.JsonDateSerializer;
+
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-
-import org.osiam.resources.helper.JsonDateSerializer;
-
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * This class represents the meta data of a resource.
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02">SCIM core schema 2.0</a>
  * </p>
  */
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Meta implements Serializable {
 
     private static final long serialVersionUID = -4536271487921469946L;

--- a/src/main/java/org/osiam/resources/scim/Name.java
+++ b/src/main/java/org/osiam/resources/scim/Name.java
@@ -24,20 +24,20 @@
 package org.osiam.resources.scim;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.base.Strings;
 
 import java.io.Serializable;
 
 /**
  * This class represents the User's real name.
- *
+ * <p/>
  * <p>
  * For more detailed information please look at the <a
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
  * </p>
  */
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Name implements Serializable {
 
     private static final long serialVersionUID = -2090787512643160922L;
@@ -66,7 +66,7 @@ public class Name implements Serializable {
 
     /**
      * Gets the full name, including all middle names, titles, and suffixes as appropriate, formatted for display.
-     *
+     * <p/>
      * <p>
      * For more detailed information please look at the <a
      * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
@@ -80,7 +80,7 @@ public class Name implements Serializable {
 
     /**
      * Gets the family name of the User.
-     *
+     * <p/>
      * <p>
      * For more detailed information please look at the <a
      * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
@@ -94,7 +94,7 @@ public class Name implements Serializable {
 
     /**
      * Gets the given (first) name of the User.
-     *
+     * <p/>
      * <p>
      * For more detailed information please look at the <a
      * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
@@ -108,7 +108,7 @@ public class Name implements Serializable {
 
     /**
      * Gets the middle name(s) of the User.
-     *
+     * <p/>
      * <p>
      * For more detailed information please look at the <a
      * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
@@ -122,7 +122,7 @@ public class Name implements Serializable {
 
     /**
      * Gets the honorific prefix(es) of the User.
-     *
+     * <p/>
      * <p>
      * For more detailed information please look at the <a
      * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
@@ -136,7 +136,7 @@ public class Name implements Serializable {
 
     /**
      * Gets the honorific suffix(es) of the User.
-     *
+     * <p/>
      * <p>
      * For more detailed information please look at the <a
      * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
@@ -155,27 +155,27 @@ public class Name implements Serializable {
      */
     @JsonIgnore
     public boolean isEmpty() {
-        if(!Strings.isNullOrEmpty(formatted)) {
+        if (!Strings.isNullOrEmpty(formatted)) {
             return false;
         }
 
-        if(!Strings.isNullOrEmpty(familyName)) {
+        if (!Strings.isNullOrEmpty(familyName)) {
             return false;
         }
 
-        if(!Strings.isNullOrEmpty(givenName)) {
+        if (!Strings.isNullOrEmpty(givenName)) {
             return false;
         }
 
-        if(!Strings.isNullOrEmpty(middleName)) {
+        if (!Strings.isNullOrEmpty(middleName)) {
             return false;
         }
 
-        if(!Strings.isNullOrEmpty(honorificPrefix)) {
+        if (!Strings.isNullOrEmpty(honorificPrefix)) {
             return false;
         }
 
-        if(!Strings.isNullOrEmpty(honorificSuffix)) {
+        if (!Strings.isNullOrEmpty(honorificSuffix)) {
             return false;
         }
 
@@ -203,8 +203,7 @@ public class Name implements Serializable {
         /**
          * Sets the full name (See {@link Name#getFormatted()}).
          *
-         * @param formatted
-         *            the formatted name
+         * @param formatted the formatted name
          * @return the builder itself
          */
         public Builder setFormatted(String formatted) {
@@ -215,8 +214,7 @@ public class Name implements Serializable {
         /**
          * Sets the family name of the User (See {@link Name#getFamilyName()}).
          *
-         * @param familyName
-         *            the family name
+         * @param familyName the family name
          * @return the builder itself
          */
         public Builder setFamilyName(String familyName) {
@@ -227,8 +225,7 @@ public class Name implements Serializable {
         /**
          * Sets the given name of the User (See {@link Name#getGivenName()}).
          *
-         * @param givenName
-         *            the given name
+         * @param givenName the given name
          * @return the builder itself
          */
         public Builder setGivenName(String givenName) {
@@ -239,8 +236,7 @@ public class Name implements Serializable {
         /**
          * Sets the middle name(s) of the User (See {@link Name#getMiddleName()}).
          *
-         * @param middleName
-         *            the middle name
+         * @param middleName the middle name
          * @return the builder itself
          */
         public Builder setMiddleName(String middleName) {
@@ -251,8 +247,7 @@ public class Name implements Serializable {
         /**
          * Sets the honorific prefix(es) of the User (See {@link Name#getHonorificPrefix()}).
          *
-         * @param honorificPrefix
-         *            the honorific prefix
+         * @param honorificPrefix the honorific prefix
          * @return the builder itself
          */
         public Builder setHonorificPrefix(String honorificPrefix) {
@@ -263,8 +258,7 @@ public class Name implements Serializable {
         /**
          * Sets the honorific suffix(es) of the User (See {@link Name#getHonorificSuffix()}).
          *
-         * @param honorificSuffix
-         *            the honorific suffix
+         * @param honorificSuffix the honorific suffix
          * @return the builder itself
          */
         public Builder setHonorificSuffix(String honorificSuffix) {

--- a/src/main/java/org/osiam/resources/scim/SCIMSearchResult.java
+++ b/src/main/java/org/osiam/resources/scim/SCIMSearchResult.java
@@ -23,23 +23,22 @@
 
 package org.osiam.resources.scim;
 
-import java.util.*;
-
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.util.*;
 
 /**
  * A class that holds all information from a search request
- *
+ * <p/>
  * <p>
  * For more detailed information please look at the <a
  * href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02">SCIM core schema 2.0</a>
  * </p>
  *
- * @param <T>
- *            {@link User} or {@link Group}
+ * @param <T> {@link User} or {@link Group}
  */
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SCIMSearchResult<T> {
 
     public static final String SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse";

--- a/src/main/java/org/osiam/resources/scim/User.java
+++ b/src/main/java/org/osiam/resources/scim/User.java
@@ -24,7 +24,7 @@
 package org.osiam.resources.scim;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import org.osiam.resources.exception.SCIMDataValidationException;
@@ -33,20 +33,21 @@ import java.io.Serializable;
 import java.util.*;
 
 /**
- * User resources are meant to enable expression of common User informations. With the core attributes it should be
- * possible to express most user data. If more information need to be saved in a user object the user extension can be
+ * User resources are meant to enable expression of common User information. It should be possible to express most user
+ * data with the core attributes. If more information need to be saved in a user object the user extension can be
  * used to store all customized data.
  * <p>
  * For more detailed information please look at the
  * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-6">SCIM core schema 2.0, section 6</a>
  * </p>
  * <p>
- * client info: The scim schema is mainly meant as a connection link between the OSIAM server and by a client like the
- * connector4Java. Some values will be not accepted by the OSIAM server. These specific values have an own client info
+ * client info: The scim schema is mainly meant as a connection link between the OSIAM server and a client like the
+ * connector4Java. Some values will not be accepted by the OSIAM server. These specific values have an own client info
  * documentation section.
  * </p>
  */
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class User extends Resource implements Serializable {
 
     public static final String SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";


### PR DESCRIPTION
JsonSerialize.Inclusion has been deprecated by `JsonInclude`. This
commit also bumps the Jackson dependencies.