### PR TITLE
Deprecate ScimHelper class

### DIFF
--- a/src/main/java/org/osiam/resources/helper/SCIMHelper.java
+++ b/src/main/java/org/osiam/resources/helper/SCIMHelper.java
@@ -29,28 +29,31 @@ import org.osiam.resources.scim.User;
 import com.google.common.base.Optional;
 
 /**
- * This class is a collection of different helper methods around the scim schema context  
+ * This class is a collection of different helper methods around the scim schema context
+ * This class has been deprecated. If You want to use the only method it contains please see
+ * {@link User#getPrimaryOrFirstEmail()}
  */
+@Deprecated
 public class SCIMHelper {
 
-    private SCIMHelper(){
-    }
-    
+
     /**
-     * try to extract an email from the User. 
+     * try to extract an email from the User.
      * If the User has a primary email address this email will be returned.
      * If not the first email address found will be returned.
-     * If no Email has been found email.isPresent() == false 
+     * If no Email has been found email.isPresent() == false
      * @param user a {@link User} with a possible email
      * @return an email if found
+     * @deprecated Please use the method {@link User#getPrimaryOrFirstEmail()}
      */
+    @Deprecated
     public static Optional<Email> getPrimaryOrFirstEmail(User user){
         for (Email email : user.getEmails()) {
             if (email.isPrimary()) {
                 return Optional.of(email);
             }
         }
-        
+
         if(user.getEmails().size() > 0){
             return Optional.of(user.getEmails().get(0));
         }

--- a/src/main/java/org/osiam/resources/scim/User.java
+++ b/src/main/java/org/osiam/resources/scim/User.java
@@ -24,8 +24,10 @@
 package org.osiam.resources.scim;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import org.osiam.resources.exception.SCIMDataValidationException;
 
@@ -276,6 +278,28 @@ public class User extends Resource implements Serializable {
      */
     public List<Email> getEmails() {
         return emails;
+    }
+
+    /**
+     * try to extract an email from the User.
+     * If the User has a primary email address this email will be returned.
+     * If not the first email address found will be returned.
+     * If no Email has been found email.isPresent() == false
+     *
+     * @return an email if found
+     */
+    @JsonIgnore
+    public Optional<Email> getPrimaryOrFirstEmail() {
+        for (Email email : emails) {
+            if (email.isPrimary()) {
+                return Optional.of(email);
+            }
+        }
+
+        if (emails.size() > 0) {
+            return Optional.of(getEmails().get(0));
+        }
+        return Optional.absent();
     }
 
     /**

--- a/src/test/groovy/org/osiam/resources/scim/UserSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/UserSpec.groovy
@@ -25,11 +25,10 @@ package org.osiam.resources.scim
 
 import org.apache.commons.lang3.SerializationUtils
 import org.osiam.test.util.DateHelper
-
-import java.nio.ByteBuffer
-
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import java.nio.ByteBuffer
 
 class UserSpec extends Specification {
 
@@ -301,8 +300,50 @@ class UserSpec extends Specification {
         newUser = new User.Builder(newUserName, oldUser).build()
 
         then:
-        newUser.isActive() == true
+        newUser.isActive()
         newUser.getUserName() == newUserName
+    }
+
+    def 'the primary email is returned'() {
+        given:
+        User user = new User.Builder("user")
+                .addEmail(getEmail())
+                .build()
+
+        expect:
+        user.getPrimaryOrFirstEmail().present
+        user.getPrimaryOrFirstEmail().get().primary
+    }
+
+    def 'the first nonprimary email is returned'() {
+        given:
+        def first = new Email.Builder()
+                .setPrimary(false)
+                .setValue('first@tarent.de')
+                .build()
+
+        def second = new Email.Builder()
+                .setPrimary(false)
+                .setValue('second@tarent.de')
+                .build()
+
+        when:
+        def user = new User.Builder("user")
+                .addEmail(first)
+                .addEmail(second)
+                .build()
+
+        then:
+        user.primaryOrFirstEmail.present
+        user.primaryOrFirstEmail.get() == first
+    }
+
+    def "no email is returned if the user doesn't have one"() {
+        given:
+        def user = new User.Builder("user").build()
+
+        expect:
+        !user.primaryOrFirstEmail.present
     }
 
     Email getEmail() {
@@ -444,7 +485,7 @@ class UserSpec extends Specification {
         user.isActive() == newUser.isActive()
 
         newUser.getExtension('urn:scim:schemas:extension:test:1.0:User').getFieldAsString('keyString') == 'example'
-        newUser.getExtension('urn:scim:schemas:extension:test:1.0:User').getFieldAsBoolean('keyBoolean') == true
+        newUser.getExtension('urn:scim:schemas:extension:test:1.0:User').getFieldAsBoolean('keyBoolean')
         newUser.getExtension('urn:scim:schemas:extension:test:1.0:User').getFieldAsInteger('keyInteger') == 123G
         newUser.getExtension('urn:scim:schemas:extension:test:1.0:User').getFieldAsDecimal('keyDecimal') == 123.456G
         newUser.getExtension('urn:scim:schemas:extension:test:1.0:User')


### PR DESCRIPTION
Mark dubious and untested class `ScimHelper` as `@Deprecated` and move
its only provided method where it belongs to the `User` class. Also adds
tests for the method.