### PR TITLE
Add method to add single Member to Group

### DIFF
--- a/src/main/java/org/osiam/resources/scim/Group.java
+++ b/src/main/java/org/osiam/resources/scim/Group.java
@@ -23,24 +23,23 @@
 
 package org.osiam.resources.scim;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.google.common.base.Strings;
+import org.osiam.resources.exception.SCIMDataValidationException;
+
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.osiam.resources.exception.SCIMDataValidationException;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.google.common.base.Strings;
-
 /**
  * This class represent a Group resource.
- *
+ * <p/>
  * <p>
  * For more detailed information please look at the
  * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-8">SCIM core schema 2.0, sections 8</a>
  * </p>
- *
+ * <p/>
  * <p>
  * client info: The scim schema is mainly meant as a connection link between the OSIAM server and by a client like the
  * connector4Java. Some values will be not accepted by the OSIAM server. These specific values have an own client info
@@ -79,7 +78,7 @@ public class Group extends Resource implements Serializable {
 
     /**
      * Gets the list of members of this Group.
-     *
+     * <p/>
      * <p>
      * For more detailed information please look at the
      * <a href="http://tools.ietf.org/html/draft-ietf-scim-core-schema-02#section-8">SCIM core schema 2.0, sections
@@ -111,10 +110,8 @@ public class Group extends Resource implements Serializable {
          * creates a new Group.Builder based on the given displayName and group. All values of the given group will be
          * copied expect the displayName will be be overridden by the given one
          *
-         * @param displayName
-         *        the new displayName of the group
-         * @param group
-         *        a existing group
+         * @param displayName the new displayName of the group
+         * @param group       a existing group
          */
         public Builder(String displayName, Group group) {
             super(group);
@@ -138,11 +135,8 @@ public class Group extends Resource implements Serializable {
         /**
          * Constructs a new builder by copying all values from the given {@link Group}
          *
-         * @param group
-         *        {@link Group} to be copied from
-         *
-         * @throws SCIMDataValidationException
-         *         if the given group is null
+         * @param group {@link Group} to be copied from
+         * @throws SCIMDataValidationException if the given group is null
          */
         public Builder(Group group) {
             this(null, group);
@@ -154,11 +148,8 @@ public class Group extends Resource implements Serializable {
         /**
          * Constructs a new builder and sets the display name (See {@link Group#getDisplayName()}).
          *
-         * @param displayName
-         *        the display name
-         *
-         * @throws SCIMDataValidationException
-         *         if the displayName is null or empty
+         * @param displayName the display name
+         * @throws SCIMDataValidationException if the displayName is null or empty
          */
         public Builder(String displayName) {
             this(displayName, null);
@@ -187,7 +178,7 @@ public class Group extends Resource implements Serializable {
 
         /**
          * @deprecated Don't use this method - let the extensions add their schema themselves. Will be removed in
-         *             version 1.8 or 2.0
+         * version 1.8 or 2.0
          */
         @Override
         @Deprecated
@@ -199,12 +190,22 @@ public class Group extends Resource implements Serializable {
         /**
          * Sets the list of members as {@link Set} (See {@link Group#getMembers()}).
          *
-         * @param members
-         *        the set of members
+         * @param members the set of members
          * @return the builder itself
          */
         public Builder setMembers(Set<MemberRef> members) {
             this.members = members;
+            return this;
+        }
+
+        /**
+         * Add the given member to the set of members.
+         *
+         * @param member The member to add.
+         * @return The builder itself
+         */
+        public Builder addMember(MemberRef member) {
+            members.add(member);
             return this;
         }
 

--- a/src/test/groovy/org/osiam/resources/scim/GroupSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/scim/GroupSpec.groovy
@@ -55,11 +55,10 @@ class GroupSpec extends Specification {
         group.id == 'id'
     }
 
-    def 'should be able to enrich group members'() {
-        given:
-        def group = new Group.Builder('display').build()
+    def 'should be able to add member to group'() {
         when:
-        group.members.add(new MemberRef.Builder().build())
+        def group = new Group.Builder('display')
+                .addMember(new MemberRef.Builder().build()).build()
 
         then:
         group.members.size() == 1


### PR DESCRIPTION
In preparation to make the scim-schema completely immutable add a method
to the builder to add a single `MemberRef` to the group.

This sets up the scim-schema to completely work on #126