### PR TITLE
Deprecate UpdateUser, UpdateGroup and Enterprise

### DIFF
--- a/src/main/java/org/osiam/resources/scim/SCIMSearchResult.java
+++ b/src/main/java/org/osiam/resources/scim/SCIMSearchResult.java
@@ -44,7 +44,7 @@ public class SCIMSearchResult<T> {
     private long totalResults;
     private long itemsPerPage;
     private long startIndex;
-    private Set<String> schemas = new HashSet<>(Arrays.asList(SCHEMA));
+    private Set<String> schemas = new HashSet<>(Collections.singletonList(SCHEMA));
     private List<T> resources = new ArrayList<>();
 
     /**


### PR DESCRIPTION
Add the `@Deprecated` annotation to the classses `UpdateUser`, `UpdateGroup` and `Enterprise`. We consider them deprecated and want to delete them in the near future.