### PR TITLE
Make validated schema in `UserDeserializer` configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # OSIAM SCIM Schema
 
+## 1.6 - Unreleased
+
+### Features
+
+- Make validated schema in `UserDeserializer` configurable
+
+    This adds the ability to set the schema that the `UserDeserializer`
+    implicitly validates to a custom value using the new constructor
+    `UserDeserializer#UserDeserializer(String schema)`.
+
+### Changes
+
+- Deprecate `UserDeserializer#UserDeserializer(Class<?> valueClass)`
+
 ## 1.5 - 2015-09-09
 
 ### Fixes

--- a/src/main/java/org/osiam/resources/helper/UserDeserializer.java
+++ b/src/main/java/org/osiam/resources/helper/UserDeserializer.java
@@ -48,15 +48,31 @@ public class UserDeserializer extends StdDeserializer<User> {
         MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
+    private final String schema;
+
+    /**
+     * Create a {@link UserDeserializer} that validates the {@link User} against {@link User#SCHEMA}.
+     */
     public UserDeserializer() {
-        super(User.class);
+        this(User.SCHEMA);
     }
 
     /**
-     * @deprecated Use {@link UserDeserializer#UserDeserializer()}. Will be removed in 1.9 or 2.0.
+     * Create a {@link UserDeserializer} that validates the {@link User} against the given schema
+     * instead of {@link User#SCHEMA}.
+     */
+    public UserDeserializer(String schema) {
+        super(User.class);
+        this.schema = schema;
+    }
+
+    /**
+     * @deprecated Use {@link UserDeserializer#UserDeserializer()} or
+     * {@link UserDeserializer#UserDeserializer(String)}. Will be removed in 1.9 or 2.0.
      */
     public UserDeserializer(Class<?> valueClass) {
         super(valueClass);
+        this.schema = User.SCHEMA;
     }
 
     @Override
@@ -74,7 +90,7 @@ public class UserDeserializer extends StdDeserializer<User> {
         User.Builder builder = new User.Builder(user);
 
         for (String urn : user.getSchemas()) {
-            if (urn.equals(User.SCHEMA)) {
+            if (urn.equals(schema)) {
                 continue;
             }
 

--- a/src/main/java/org/osiam/resources/helper/UserDeserializer.java
+++ b/src/main/java/org/osiam/resources/helper/UserDeserializer.java
@@ -48,6 +48,13 @@ public class UserDeserializer extends StdDeserializer<User> {
         MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
+    public UserDeserializer() {
+        super(User.class);
+    }
+
+    /**
+     * @deprecated Use {@link UserDeserializer#UserDeserializer()}. Will be removed in 1.9 or 2.0.
+     */
     public UserDeserializer(Class<?> valueClass) {
         super(valueClass);
     }

--- a/src/test/groovy/org/osiam/test/util/JsonFixturesHelper.groovy
+++ b/src/test/groovy/org/osiam/test/util/JsonFixturesHelper.groovy
@@ -55,7 +55,7 @@ class JsonFixturesHelper {
     public ObjectMapper configuredObjectMapper() {
         ObjectMapper mapper = new ObjectMapper()
         SimpleModule testModule = new SimpleModule('MyModule', new Version(1, 0, 0, null))
-                .addDeserializer(User, new UserDeserializer(User))
+                .addDeserializer(User, new UserDeserializer())
         mapper.registerModule(testModule)
         return mapper
     }


### PR DESCRIPTION
This adds the ability to set the schema that the `UserDeserializer`
implicitly validates to a custom value using the new constructor
`UserDeserializer#UserDeserializer(String schema)`.

This feature is needed by components that have to support the old URNs,
that were defined up to draft 08.

Also deprecates an old constructor, that turned out to be useless.