### PR TITLE
Enable code coverage reporting

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,15 @@
 dependencies:
   override:
     - mvn -U dependency:resolve dependency:resolve-plugins
+    - curl http://www.jpm4j.org/install/script > jpmInstall.sh
+    - sudo sh jpmInstall.sh
+    - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
 test:
   override:
     - mvn verify
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/target/.*-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+    - cp -r target/coverage-reports/jacoco/ $CIRCLE_ARTIFACTS
+    - test -z $CODACY_PROJECT_TOKEN || codacy-coverage-reporter -l Java -r target/coverage-reports/jacoco/jacoco.xml --projectToken $CODACY_PROJECT_TOKEN
+    - test -z $COVERALLS_REPO_TOKEN || mvn coveralls:report -DrepoToken=$COVERALLS_REPO_TOKEN

--- a/pom.xml
+++ b/pom.xml
@@ -214,11 +214,47 @@
                 <configuration>
                     <parallel>classes</parallel>
                     <threadCount>3</threadCount>
-                    <argLine>-XX:-UseSplitVerifier</argLine>
+                    <argLine>${argLine} -XX:-UseSplitVerifier</argLine>
                     <includes>
                         <include>**/*Test.*</include>
                         <include>**/*Spec.*</include>
                     </includes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.5.201505241946</version>
+                <configuration>
+                    <dataFile>${project.build.directory}/coverage-reports/jacoco.exec</dataFile>
+                    <destFile>${project.build.directory}/coverage-reports/jacoco.exec</destFile>
+                    <outputDirectory>${project.build.directory}/coverage-reports/jacoco/</outputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pre-unit-tests</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-tests</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <configuration>
+                    <jacocoReports>
+                        <entry>${project.build.directory}/coverage-reports/jacoco/jacoco.xml</entry>
+                    </jacocoReports>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Enable the generation of code coverage information and transmit the information to both (codacy.com)[https://www.codacy.com/] and (coveralls)[https://coveralls.io].