### PR TITLE
Remove unnecessary maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,40 +282,6 @@
     </build>
 
     <profiles>
-        <!-- ==================== Profile: coverage ==================== -->
-        <profile>
-            <id>coverage</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>cobertura-maven-plugin</artifactId>
-                        <version>2.7</version>
-                        <configuration>
-                            <formats>
-                                <format>xml</format>
-                            </formats>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>generate-data</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>cobertura</goal>
-                                </goals>
-                                <configuration>
-                                    <quiet>true</quiet>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <!-- ==================== Profile: build internally for snapshot runs ==================== -->
         <!-- Deployment needs to be run from jenkins server which has credentials to access the internal snapshot repository -->
         <profile>


### PR DESCRIPTION
Since we switched to jacoco for coverage reporting we don't need this maven profile any more (and it probably just got forgotten when working on #169)
